### PR TITLE
Add access request page for super admins

### DIFF
--- a/backend/src/controllers/authControllers.ts
+++ b/backend/src/controllers/authControllers.ts
@@ -191,7 +191,7 @@ export const login = async (req: Request, res: Response): Promise<void> => {
       return;
     }
 
-    const accessToken = jwt.sign({ email }, process.env.JWT_SECRET as string, {
+    const accessToken = jwt.sign({ email , isSuperAdmin: user.status === "super-admin" }, process.env.JWT_SECRET as string, {
       expiresIn: process.env.JWT_ACCESS_EXPIRES_IN as string,
     });
     const refreshToken = jwt.sign({ email }, process.env.JWT_SECRET as string, {
@@ -261,6 +261,23 @@ export const requestAccess = async (
     res.status(500).json({ message: "An error occurred", error });
     console.log(error);
   }
+};
+
+export const getAccessRequests = async (
+  _req: Request,
+  res: Response
+): Promise<void> => {
+  const accessRequests = await Admin.find({ status: "requested" }) ?? [];
+  res.status(200).json({ accessRequests });
+};
+
+export const rejectRequest = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  const email = req.body.email;
+  await Admin.deleteOne({ email: email });
+  res.status(200).json({ message: "Request rejected successfully." });
 };
 
 export const acceptRequest = async (

--- a/backend/src/routes/userRoutes.ts
+++ b/backend/src/routes/userRoutes.ts
@@ -7,6 +7,8 @@ import {
   requestAccess,
   acceptRequest,
   logout,
+  getAccessRequests,
+  rejectRequest,
 } from "@/controllers/authControllers";
 import { adminCheck } from "@/middleware/adminAccessOnly";
 import { superAdminCheck } from "@/middleware/superAdminAccessOnly";
@@ -16,6 +18,9 @@ router.post("/guestRegister", guestUserRegister);
 router.post("/adminRegister", adminUserRegister);
 router.post("/login", login);
 router.post("/requestAccess", requestAccess);
-router.post("/acceptRequest", superAdminCheck, acceptRequest);
+router.get("/getAccessRequests", validTokenCheck, superAdminCheck, getAccessRequests);
+router.post("/rejectRequest", validTokenCheck, superAdminCheck, rejectRequest);
+router.post("/acceptRequest", validTokenCheck, superAdminCheck, acceptRequest);
+
 router.post("/logout", validTokenCheck, logout);
 export default router;

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -4,6 +4,8 @@ import { useAuth } from "@/contexts/AuthContext";
 import { Button } from "./ui/Button";
 import { LogOut } from "lucide-react";
 import { useLogout } from "@/hooks/useLogout";
+import { jwtDecode } from "jwt-decode";
+import { CustomJwtPayload } from "@/types/auth";
 
 const NavItem = ({
   to,
@@ -24,7 +26,7 @@ const NavItem = ({
 };
 
 export function Header() {
-  const { accessToken } = useAuth();
+  const { accessToken, isSuperAdmin } = useAuth();
   const { mutate: logout, isLoading } = useLogout();
 
   return (
@@ -44,6 +46,9 @@ export function Header() {
 
               {!!accessToken && (
                 <NavItem to="/create-event">Create Event</NavItem>
+              )}
+              {isSuperAdmin && (
+                <NavItem to="/access-requests">Access Requests</NavItem>
               )}
               {!!accessToken ? (
                 <Button 

--- a/frontend/src/components/SuperAdminRoute.tsx
+++ b/frontend/src/components/SuperAdminRoute.tsx
@@ -1,17 +1,18 @@
 import { Navigate, useLocation } from "react-router";
 import { useAuth } from "@/contexts/AuthContext";
+import { jwtDecode } from "jwt-decode";
 
-export function ProtectedRoute({ children }: { children: React.ReactNode }) {
-  const { accessToken, isLoading } = useAuth();
+export function SuperAdminRoute({ children }: { children: React.ReactNode }) {
+  const { accessToken, isSuperAdmin } = useAuth();
   const location = useLocation();
-
-  if (isLoading) {
-    return null; 
-  }
 
   if (!accessToken) {
     return <Navigate to="/login" state={{ from: location }} replace />;
   }
 
+  if (!isSuperAdmin) {
+    return <Navigate to="/events" replace />;
+  }
+
   return <>{children}</>;
-}
+} 

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -1,9 +1,16 @@
 /// <reference types="vite/client" />
 
+import { JwtPayload as JwtPayloadType } from "jwt-decode";
 interface ImportMetaEnv {
   readonly VITE_API_URL: string
 }
 
 interface ImportMeta {
   readonly env: ImportMetaEnv
+}
+
+declare module "jwt-decode" {
+  export interface JwtPayload extends JwtPayloadType {
+    isSuperAdmin: boolean;
+  }
 }

--- a/frontend/src/hooks/useAcceptAccessRequest.ts
+++ b/frontend/src/hooks/useAcceptAccessRequest.ts
@@ -1,0 +1,18 @@
+import { useMutation, UseMutationOptions } from "react-query";
+import { axios } from "@/lib/axios";
+
+type AcceptAccessResponse =  {
+  message: string;
+}
+
+export function useAcceptAccessRequest(
+  options?: UseMutationOptions<AcceptAccessResponse, Error, string>
+) {
+  return useMutation<AcceptAccessResponse, Error, string>(
+    async (email) => {
+      const { data } = await axios.post<AcceptAccessResponse>(`/users/acceptRequest`, { email });
+      return data;
+    },
+    options
+  );
+}

--- a/frontend/src/hooks/useGetAccessRequests.ts
+++ b/frontend/src/hooks/useGetAccessRequests.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "react-query";
+import { axios } from "@/lib/axios";
+
+type AccessRequestsResponse = {
+  accessRequests: {
+    createdAt: string;
+    email: string;
+    status: string;
+    updatedAt: string;
+  }[];
+};
+
+export function useGetAccessRequests() {
+  return useQuery<AccessRequestsResponse["accessRequests"]>(
+    "accessRequests",
+    async () => {
+      const { data } = await axios.get<AccessRequestsResponse>(
+        "/users/getAccessRequests"
+      );
+
+    return data.accessRequests;
+  });
+}

--- a/frontend/src/hooks/useLogin.ts
+++ b/frontend/src/hooks/useLogin.ts
@@ -3,6 +3,8 @@ import { axios } from "@/lib/axios";
 import { useAuth } from "@/contexts/AuthContext";
 import { toast } from "react-hot-toast";
 import { isAxiosError } from "axios";
+import { useNavigate } from "react-router";
+import { jwtDecode } from "jwt-decode";
 
 export type LoginCredentials = {
   email: string;
@@ -17,6 +19,7 @@ export type LoginResponse = {
 
 export function useLogin() {
   const { setSession } = useAuth();
+  const navigate = useNavigate();
 
   return useMutation<LoginResponse, Error, LoginCredentials>(
     async (credentials) => {
@@ -29,7 +32,13 @@ export function useLogin() {
     {
       onSuccess: (data) => {
         setSession(data);
-        // TODO: redirect to create event page
+        const decoded = jwtDecode(data.accessToken);
+
+        if (decoded.isSuperAdmin) {
+          navigate("/access-requests");
+        } else {
+          navigate("/create-event");
+        }
       },
       onError: (e) => {
         if (isAxiosError(e)) {

--- a/frontend/src/hooks/useRejectAccessRequest.ts
+++ b/frontend/src/hooks/useRejectAccessRequest.ts
@@ -1,0 +1,18 @@
+import { useMutation, UseMutationOptions } from "react-query";
+import { axios } from "@/lib/axios";
+
+type RejectAccessResponse =  {
+  message: string;
+}
+
+export function useRejectAccessRequest(
+  options?: UseMutationOptions<RejectAccessResponse, Error, string>
+) {
+  return useMutation<RejectAccessResponse, Error, string>(
+    async (email) => {
+      const { data } = await axios.post<RejectAccessResponse>(`/users/rejectRequest`, { email });
+      return data;
+    },
+    options
+  );
+} 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,6 +7,8 @@ import Events from "./pages/Events";
 import CreateEvent from "./pages/CreateEvent";
 import { ProtectedRoute } from "./components/ProtectedRoute";
 import Register from "./pages/Register";
+import AccessRequests from "@/pages/AccessRequests";
+import { SuperAdminRoute } from "@/components/SuperAdminRoute";
 
 const router = createBrowserRouter([
   {
@@ -36,6 +38,14 @@ const router = createBrowserRouter([
       {
         path: "/",
         element: <Navigate to="/events" replace />,
+      },
+      {
+        path: "/access-requests",
+        element: (
+          <SuperAdminRoute>
+            <AccessRequests />
+          </SuperAdminRoute>
+        ),
       },
     ],
   },

--- a/frontend/src/pages/AccessRequests.tsx
+++ b/frontend/src/pages/AccessRequests.tsx
@@ -1,0 +1,82 @@
+import { useGetAccessRequests } from "@/hooks/useGetAccessRequests";
+import { useAcceptAccessRequest } from "@/hooks/useAcceptAccessRequest";
+import { useRejectAccessRequest } from "@/hooks/useRejectAccessRequest";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { toast } from "react-hot-toast";
+import { Check, X } from "lucide-react";
+
+export default function AccessRequests() {
+  const { data: requests, isLoading, refetch } = useGetAccessRequests();
+  const { mutate: acceptRequest, isLoading: isAccepting } = useAcceptAccessRequest();
+  const { mutate: rejectRequest, isLoading: isRejecting } = useRejectAccessRequest();
+
+  const handleAccept = (email: string) => {
+    acceptRequest(email, {
+      onSuccess: () => {
+        toast.success("Request accepted successfully");
+        refetch();
+      },
+      onError: () => {
+        toast.error("Failed to accept request");
+      },
+    });
+  };
+
+  const handleReject = (email: string) => {
+    rejectRequest(email, {
+      onSuccess: () => {
+        toast.success("Request rejected successfully");
+        refetch();
+      },
+      onError: () => {
+        toast.error("Failed to reject request");
+      },
+    });
+  };
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div className="w-full max-w-4xl space-y-4">
+      <h1 className="text-2xl font-bold">Access Requests</h1>
+      {requests?.length === 0 ? (
+        <Card className="p-4">
+          <p className="text-muted-foreground">No pending access requests</p>
+        </Card>
+      ) : (
+        <div className="space-y-4">
+          {requests?.map((request: { email: string }) => (
+            <Card key={request.email} className="p-4">
+              <div className="flex items-center justify-between flex-wrap gap-2">
+                <span className="text-lg">{request.email}</span>
+                <div className="flex gap-2">
+                  <Button
+                    onClick={() => handleAccept(request.email)}
+                    disabled={isAccepting || isRejecting}
+                    variant="default"
+                    className="gap-2"
+                  >
+                    <Check className="w-4 h-4" />
+                    Accept
+                  </Button>
+                  <Button
+                    onClick={() => handleReject(request.email)}
+                    disabled={isAccepting || isRejecting}
+                    variant="destructive"
+                    className="gap-2"
+                  >
+                    <X className="w-4 h-4" />
+                    Reject
+                  </Button>
+                </div>
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+} 

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -95,6 +95,7 @@ export default function Register() {
               />
             </div>
           </CardContent>
+          </form>
           <CardFooter className="flex flex-col gap-4">
             <Button type="submit" className="w-full" isLoading={isLoading}>
               Register
@@ -144,7 +145,6 @@ export default function Register() {
               </ModalContent>
             </Modal>
           </CardFooter>
-        </form>
       </Card>
     </>
   );


### PR DESCRIPTION
Adds new functionality for managing admin access requests and improves the login process. The changes include adding a flag for super-admin status in the JWT token, implementing new endpoints for fetching and rejecting access requests, and updating the routes to use appropriate middleware for enhanced security. These improvements provide better control over admin access and streamline the request management process.